### PR TITLE
Add CI/CD Workflow for Multi-Platform Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest]
     
     runs-on: ${{ matrix.platform }}
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,119 @@
+name: Build Claudia
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:  # Allows manual trigger
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-22.04, macos-latest, windows-latest]
+        
+    runs-on: ${{ matrix.platform }}
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: latest
+
+    - name: Install system dependencies (Ubuntu)
+      if: matrix.platform == 'ubuntu-22.04'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev \
+          patchelf \
+          build-essential \
+          curl \
+          wget \
+          file \
+          libssl-dev \
+          libxdo-dev \
+          libsoup-3.0-dev \
+          libjavascriptcoregtk-4.1-dev
+
+    - name: Install system dependencies (macOS)
+      if: matrix.platform == 'macos-latest'
+      run: |
+        # Install Xcode Command Line Tools if not present
+        xcode-select --install || true
+
+    - name: Install system dependencies (Windows)
+      if: matrix.platform == 'windows-latest'
+      run: |
+        # Dependencies should be available on GitHub Actions Windows runners
+        echo "Windows dependencies should be pre-installed"
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+          node_modules/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-bun-${{ hashFiles('**/bun.lockb') }}
+
+    - name: Install frontend dependencies
+      run: bun install
+
+    - name: Build application
+      run: bun run tauri build
+
+    - name: List build artifacts (Debug)
+      run: |
+        echo "Build artifacts:"
+        find src-tauri/target/release/bundle -type f -name "*" || true
+        ls -la src-tauri/target/release/ || true
+
+    - name: Upload artifacts (Linux)
+      if: matrix.platform == 'ubuntu-22.04'
+      uses: actions/upload-artifact@v3
+      with:
+        name: claudia-linux
+        path: |
+          src-tauri/target/release/bundle/appimage/*.AppImage
+          src-tauri/target/release/bundle/deb/*.deb
+          src-tauri/target/release/claudia
+        if-no-files-found: warn
+
+    - name: Upload artifacts (macOS)
+      if: matrix.platform == 'macos-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: claudia-macos
+        path: |
+          src-tauri/target/release/bundle/dmg/*.dmg
+          src-tauri/target/release/bundle/macos/*.app
+          src-tauri/target/release/claudia
+        if-no-files-found: warn
+
+    - name: Upload artifacts (Windows)
+      if: matrix.platform == 'windows-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: claudia-windows
+        path: |
+          src-tauri/target/release/bundle/msi/*.msi
+          src-tauri/target/release/bundle/nsis/*.exe
+          src-tauri/target/release/claudia.exe
+        if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,107 +1,261 @@
 # .github/workflows/build.yml
 name: Build Claudia
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  workflow_dispatch:    # This allows manual triggering
-  release:              # This triggers on release creation
-    types: [created]
+  workflow_dispatch:
+
+env:
+  # Global environment variables for consistent builds
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
 
 jobs:
   build:
+    name: Build ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    
     strategy:
+      fail-fast: false  # Continue building other platforms even if one fails
       matrix:
-        platform: [ubuntu-latest, macos-latest] # Remove windows-latest temporarily
-        # platform: [ubuntu-latest, windows-latest, macos-latest] # Restore after Windows fixes
-    
-    runs-on: ${{ matrix.platform }}
+        config:
+          - name: "Linux (Ubuntu)"
+            os: ubuntu-latest
+            target: ""
+            artifact_path: "src-tauri/target/release/bundle/"
+          
+          # Windows build currently disabled due to known issues:
+          # - Invalid ICO file format (Issue #83)
+          # - Unix-only imports in sandbox/executor.rs (Issue #83)
+          # Uncomment after fixes are merged:
+          # - name: "Windows"
+          #   os: windows-latest
+          #   target: ""
+          #   artifact_path: "src-tauri/target/release/bundle/"
+          
+          - name: "macOS (Apple Silicon)"
+            os: macos-latest
+            target: ""
+            artifact_path: "src-tauri/target/release/bundle/"
+          
+          # macOS Universal build currently disabled due to missing binaries:
+          # - Missing claude-code-x86_64-apple-darwin binary in binaries/ directory
+          # - Only claude-code-aarch64-apple-darwin is available
+          # Uncomment and use target: "universal-apple-darwin" after Intel binary is added:
+          # - name: "macOS (Universal)"
+          #   os: macos-latest
+          #   target: "universal-apple-darwin"
+          #   artifact_path: "src-tauri/target/universal-apple-darwin/release/bundle/"
     
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
-    
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v1
-      with:
-        bun-version: latest
-    
-    - name: Install Linux dependencies
-      if: matrix.platform == 'ubuntu-latest'
-      run: |
-        sudo apt update
-        sudo apt install -y \
-          libwebkit2gtk-4.1-dev \
-          libgtk-3-dev \
-          libayatana-appindicator3-dev \
-          librsvg2-dev \
-          patchelf \
-          libxdo-dev \
-          libsoup-3.0-dev \
-          libjavascriptcoregtk-4.1-dev
-    
-    - name: Install frontend dependencies
-      run: bun install
-    
-    - name: Build application (Universal macOS)
-      if: matrix.platform == 'macos-latest'
-      run: bun run tauri build --target universal-apple-darwin
-      env:
-        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-    
-    - name: Build application (Other platforms)
-      if: matrix.platform != 'macos-latest'
-      run: bun run tauri build
-      env:
-        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-    
-    - name: Upload artifacts (macOS Universal)
-      if: matrix.platform == 'macos-latest'
-      uses: actions/upload-artifact@v4
-      with:
-        name: claudia-${{ matrix.platform }}
-        path: |
-          src-tauri/target/universal-apple-darwin/release/bundle/
-          src-tauri/target/universal-apple-darwin/release/claudia*
-        retention-days: 30
-    
-    - name: Upload artifacts (Other platforms)
-      if: matrix.platform != 'macos-latest'
-      uses: actions/upload-artifact@v4
-      with:
-        name: claudia-${{ matrix.platform }}
-        path: |
-          src-tauri/target/release/bundle/
-          src-tauri/target/release/claudia*
-        retention-days: 30
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Ensure we have the full history for proper version detection
+          fetch-depth: 0
+      
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Add target for universal builds when enabled
+          targets: ${{ matrix.config.target }}
+          components: rustfmt, clippy
+      
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          # Cache key includes target for cross-compilation support
+          key: ${{ matrix.config.os }}-${{ matrix.config.target }}
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      
+      - name: Setup Node.js (fallback for Bun compatibility)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      
+      - name: Install Linux system dependencies
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libssl-dev \
+            libxdo-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+      
+      - name: Install macOS system dependencies
+        if: matrix.config.os == 'macos-latest'
+        run: |
+          # Ensure Xcode Command Line Tools are available
+          xcode-select --install 2>/dev/null || true
+          # Install additional dependencies if needed
+          # brew install pkg-config (uncomment if required)
+      
+      # Windows dependencies would go here when Windows builds are enabled:
+      # - name: Install Windows system dependencies
+      #   if: matrix.config.os == 'windows-latest'
+      #   run: |
+      #     # Ensure Microsoft C++ Build Tools are available
+      #     # choco install visualcpp-build-tools (if using chocolatey)
+      
+      - name: Install frontend dependencies
+        run: bun install
+      
+      - name: Run frontend type checking
+        run: bunx tsc --noEmit
+      
+      - name: Run Rust formatting check
+        working-directory: src-tauri
+        run: cargo fmt --all -- --check
+      
+      - name: Run Rust linting
+        working-directory: src-tauri
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      
+      - name: Run Rust tests
+        working-directory: src-tauri
+        run: cargo test --verbose
+      
+      - name: Build application
+        run: |
+          if [ "${{ matrix.config.target }}" != "" ]; then
+            bun run tauri build --target ${{ matrix.config.target }}
+          else
+            bun run tauri build
+          fi
+        shell: bash
+        env:
+          # Code signing environment variables (optional)
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          # Ensure consistent builds across platforms
+          TAURI_BUNDLE_IDENTIFIER: so.asterisk.claudia
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: claudia-${{ matrix.config.name }}
+          path: |
+            ${{ matrix.config.artifact_path }}
+            src-tauri/target/release/claudia*
+            src-tauri/target/${{ matrix.config.target }}/release/claudia*
+          retention-days: 30
+          if-no-files-found: warn
+      
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ matrix.config.name }}
+          path: |
+            src-tauri/target/release/build/*/out.log
+            src-tauri/target/release/build/*/err.log
+          retention-days: 7
+          if-no-files-found: ignore
 
-  release:
-    needs: build
+  # Security and quality checks
+  security-audit:
+    name: Security Audit
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      
+      - name: Run security audit
+        working-directory: src-tauri
+        run: cargo audit
+
+  # Release job - creates GitHub releases with all artifacts
+  release:
+    name: Create Release
+    needs: [build, security-audit]
+    runs-on: ubuntu-latest
+    # Only run on main branch pushes (not PRs)
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    
+    permissions:
+      contents: write  # Required for creating releases
     
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Download all artifacts
-      uses: actions/download-artifact@v4
-      with:
-        path: artifacts
-    
-    - name: Create Release
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: "artifacts/**/*"
-        tag: "v${{ github.run_number }}"
-        name: "Claudia v${{ github.run_number }}"
-        body: "Auto-generated release from commit ${{ github.sha }}"
-        draft: false
-        prerelease: false
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: claudia-*
+          merge-multiple: false
+      
+      - name: Display artifact structure
+        run: find artifacts -type f -name "*" | head -20
+      
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          echo "## 🚀 Claudia v${{ github.run_number }}" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "### 📦 Available Downloads" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "- **Linux**: AppImage, .deb package" >> release_notes.md
+          echo "- **macOS**: .dmg installer (Apple Silicon)" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "### 🔧 Build Information" >> release_notes.md
+          echo "- **Commit**: ${{ github.sha }}" >> release_notes.md
+          echo "- **Build Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> release_notes.md
+          echo "- **Workflow Run**: [${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "### ⚠️ Platform Support Status" >> release_notes.md
+          echo "- ✅ **Linux**: Fully supported" >> release_notes.md
+          echo "- ✅ **macOS**: Apple Silicon only (Intel support pending)" >> release_notes.md
+          echo "- ❌ **Windows**: Not yet supported (see issues #78, #83)" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "### 📋 Recent Changes" >> release_notes.md
+          git log --oneline -n 5 --no-decorate >> release_notes.md
+      
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/**/*"
+          tag: "v${{ github.run_number }}"
+          name: "Claudia v${{ github.run_number }}"
+          bodyFile: "release_notes.md"
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          makeLatest: true
+          allowUpdates: false
+          
+      - name: Update latest release info
+        run: |
+          echo "## Release Published Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release**: [v${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ github.run_number }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Download**: Available in [Releases](${{ github.server_url }}/${{ github.repository }}/releases)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,65 +8,144 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Cancel in-progress workflows when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-        # Windows disabled due to known issues (see #83)
-        # platform: [ubuntu-latest, windows-latest, macos-latest]
+    name: Build (${{ matrix.platform.name }})
     
-    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: Linux
+            os: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+          # Windows disabled due to known issues (see #83)
+          # - name: Windows
+          #   os: windows-latest
+          #   rust-target: x86_64-pc-windows-msvc
+          - name: macOS
+            os: macos-latest
+            rust-target: aarch64-apple-darwin
+    
+    runs-on: ${{ matrix.platform.os }}
     
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-    
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v1
-      with:
-        bun-version: latest
-    
-    - name: Install Linux dependencies
-      if: matrix.platform == 'ubuntu-latest'
-      run: |
-        sudo apt update
-        sudo apt install -y \
-          libwebkit2gtk-4.1-dev \
-          libgtk-3-dev \
-          libayatana-appindicator3-dev \
-          librsvg2-dev \
-          patchelf \
-          libxdo-dev \
-          libsoup-3.0-dev \
-          libjavascriptcoregtk-4.1-dev
-    
-    - name: Install frontend dependencies
-      run: bun install
-    
-    - name: Build application
-      run: bun run tauri build
-      # Note: Universal macOS build disabled due to missing x86_64 Claude Code binary
-      # Use: bun run tauri build --target universal-apple-darwin (after Intel binary added)
-    
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: claudia-${{ matrix.platform }}
-        path: |
-          src-tauri/target/release/bundle/
-          src-tauri/target/release/claudia*
-        retention-days: 30
+      # Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Install system dependencies for Linux
+      - name: Install Linux dependencies
+        if: matrix.platform.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libglib2.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libxdo-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev
+
+      # Setup Rust with caching
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.rust-target }}
+
+      # Cache Rust dependencies
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+          key: ${{ matrix.platform.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          
+      # Setup Bun
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Cache Bun dependencies
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun
+            node_modules
+          key: ${{ matrix.platform.os }}-bun-${{ hashFiles('bun.lockb', 'package.json') }}
+          restore-keys: |
+            ${{ matrix.platform.os }}-bun-
+      
+      # Install frontend dependencies
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      # Build frontend
+      - name: Build frontend
+        run: bun run build
+
+      # Build Tauri application with full bundles for release
+      - name: Build Tauri application
+        run: bun run tauri build --target ${{ matrix.platform.rust-target }}
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+
+      # Upload release artifacts
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: claudia-${{ matrix.platform.name }}
+          path: |
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle/deb/*.deb
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle/appimage/*.AppImage
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle/dmg/*.dmg
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle/msi/*.msi
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle/nsis/*.exe
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Upload build logs on failure
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ matrix.platform.name }}
+          path: |
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/build/*/output
+            src-tauri/target/${{ matrix.platform.rust-target }}/release/build/*/stderr
+          retention-days: 3
 
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     
     steps:
     - uses: actions/checkout@v4
+    
+    - name: Get version
+      id: version
+      run: |
+        VERSION=$(grep '^version = ' src-tauri/Cargo.toml | head -1 | cut -d '"' -f 2)
+        echo "tag=v$VERSION-build${{ github.run_number }}" >> $GITHUB_OUTPUT
     
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -77,18 +156,22 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         artifacts: "artifacts/**/*"
-        tag: "v${{ github.run_number }}"
-        name: "Claudia v${{ github.run_number }}"
+        tag: "${{ steps.version.outputs.tag }}"
+        name: "Claudia ${{ steps.version.outputs.tag }}"
         body: |
           Auto-generated release from commit ${{ github.sha }}
           
-          **Available platforms:**
-          - Linux (Ubuntu) - AppImage, .deb
-          - macOS (Apple Silicon) - .dmg
+          **Available downloads:**
+          - **Linux**: .deb package, .AppImage
+          - **macOS**: .dmg installer (Apple Silicon only)
+          
+          **Requirements:**
+          - Claude Code CLI must be installed
+          - See [installation guide](https://github.com/getAsterisk/claudia#installation) for details
           
           **Not yet supported:**
-          - Windows (see #83)
-          - macOS Universal (missing Intel binary)
+          - Windows installers (see #83)
+          - macOS Universal builds (missing Intel binary)
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+# .github/workflows/build.yml
 name: Build Claudia
 
 on:
@@ -5,115 +6,78 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  workflow_dispatch:  # Allows manual trigger
+  workflow_dispatch:
 
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, macos-latest, windows-latest]
-        
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    
     runs-on: ${{ matrix.platform }}
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
+    - uses: actions/checkout@v4
+    
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-
+        targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+    
     - name: Setup Bun
       uses: oven-sh/setup-bun@v1
       with:
         bun-version: latest
-
-    - name: Install system dependencies (Ubuntu)
-      if: matrix.platform == 'ubuntu-22.04'
+    
+    - name: Install Linux dependencies
+      if: matrix.platform == 'ubuntu-latest'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y \
+        sudo apt update
+        sudo apt install -y \
           libwebkit2gtk-4.1-dev \
           libgtk-3-dev \
           libayatana-appindicator3-dev \
           librsvg2-dev \
           patchelf \
-          build-essential \
-          curl \
-          wget \
-          file \
-          libssl-dev \
           libxdo-dev \
           libsoup-3.0-dev \
           libjavascriptcoregtk-4.1-dev
-
-    - name: Install system dependencies (macOS)
-      if: matrix.platform == 'macos-latest'
-      run: |
-        # Install Xcode Command Line Tools if not present
-        xcode-select --install || true
-
-    - name: Install system dependencies (Windows)
-      if: matrix.platform == 'windows-latest'
-      run: |
-        # Dependencies should be available on GitHub Actions Windows runners
-        echo "Windows dependencies should be pre-installed"
-
-    - name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-          node_modules/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-bun-${{ hashFiles('**/bun.lockb') }}
-
+    
     - name: Install frontend dependencies
       run: bun install
-
+    
     - name: Build application
       run: bun run tauri build
-
-    - name: List build artifacts (Debug)
-      run: |
-        echo "Build artifacts:"
-        find src-tauri/target/release/bundle -type f -name "*" || true
-        ls -la src-tauri/target/release/ || true
-
-    - name: Upload artifacts (Linux)
-      if: matrix.platform == 'ubuntu-22.04'
-      uses: actions/upload-artifact@v3
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
       with:
-        name: claudia-linux
+        name: claudia-${{ matrix.platform }}
         path: |
-          src-tauri/target/release/bundle/appimage/*.AppImage
-          src-tauri/target/release/bundle/deb/*.deb
-          src-tauri/target/release/claudia
-        if-no-files-found: warn
+          src-tauri/target/release/bundle/
+          src-tauri/target/release/claudia*
+        retention-days: 30
 
-    - name: Upload artifacts (macOS)
-      if: matrix.platform == 'macos-latest'
-      uses: actions/upload-artifact@v3
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
       with:
-        name: claudia-macos
-        path: |
-          src-tauri/target/release/bundle/dmg/*.dmg
-          src-tauri/target/release/bundle/macos/*.app
-          src-tauri/target/release/claudia
-        if-no-files-found: warn
-
-    - name: Upload artifacts (Windows)
-      if: matrix.platform == 'windows-latest'
-      uses: actions/upload-artifact@v3
+        path: artifacts
+    
+    - name: Create Release
+      uses: ncipollo/release-action@v1
       with:
-        name: claudia-windows
-        path: |
-          src-tauri/target/release/bundle/msi/*.msi
-          src-tauri/target/release/bundle/nsis/*.exe
-          src-tauri/target/release/claudia.exe
-        if-no-files-found: warn
+        artifacts: "artifacts/**/*"
+        tag: "v${{ github.run_number }}"
+        name: "Claudia v${{ github.run_number }}"
+        body: "Auto-generated release from commit ${{ github.sha }}"
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    # Simple: run on main OR manual trigger (any branch)
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     
     steps:
@@ -145,7 +146,11 @@ jobs:
       id: version
       run: |
         VERSION=$(grep '^version = ' src-tauri/Cargo.toml | head -1 | cut -d '"' -f 2)
-        echo "tag=v$VERSION-build${{ github.run_number }}" >> $GITHUB_OUTPUT
+        if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+          echo "tag=v$VERSION-test-${{ github.run_number }}" >> $GITHUB_OUTPUT
+        else
+          echo "tag=v$VERSION-build${{ github.run_number }}" >> $GITHUB_OUTPUT
+        fi
     
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -159,7 +164,7 @@ jobs:
         tag: "${{ steps.version.outputs.tag }}"
         name: "Claudia ${{ steps.version.outputs.tag }}"
         body: |
-          Auto-generated release from commit ${{ github.sha }}
+          ${{ github.ref != 'refs/heads/main' && '🧪 **TEST RELEASE**' || 'Auto-generated release' }} from commit ${{ github.sha }}
           
           **Available downloads:**
           - **Linux**: .deb package, .AppImage
@@ -172,6 +177,6 @@ jobs:
           **Not yet supported:**
           - Windows installers (see #83)
           - macOS Universal builds (missing Intel binary)
-        draft: false
-        prerelease: false
+        draft: ${{ github.ref != 'refs/heads/main' }}  # Test releases are drafts
+        prerelease: ${{ github.ref != 'refs/heads/main' }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,254 +8,87 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  # Global environment variables for consistent builds
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-
 jobs:
   build:
-    name: Build ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
-    
     strategy:
-      fail-fast: false  # Continue building other platforms even if one fails
       matrix:
-        config:
-          - name: "Linux (Ubuntu)"
-            os: ubuntu-latest
-            target: ""
-            artifact_path: "src-tauri/target/release/bundle/"
-          
-          # Windows build currently disabled due to known issues:
-          # - Invalid ICO file format (Issue #83)
-          # - Unix-only imports in sandbox/executor.rs (Issue #83)
-          # Uncomment after fixes are merged:
-          # - name: "Windows"
-          #   os: windows-latest
-          #   target: ""
-          #   artifact_path: "src-tauri/target/release/bundle/"
-          
-          - name: "macOS (Apple Silicon)"
-            os: macos-latest
-            target: ""
-            artifact_path: "src-tauri/target/release/bundle/"
-          
-          # macOS Universal build currently disabled due to missing binaries:
-          # - Missing claude-code-x86_64-apple-darwin binary in binaries/ directory
-          # - Only claude-code-aarch64-apple-darwin is available
-          # Uncomment and use target: "universal-apple-darwin" after Intel binary is added:
-          # - name: "macOS (Universal)"
-          #   os: macos-latest
-          #   target: "universal-apple-darwin"
-          #   artifact_path: "src-tauri/target/universal-apple-darwin/release/bundle/"
+        platform: [ubuntu-latest, macos-latest]
+        # Windows disabled due to known issues (see #83)
+        # platform: [ubuntu-latest, windows-latest, macos-latest]
+    
+    runs-on: ${{ matrix.platform }}
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          # Ensure we have the full history for proper version detection
-          fetch-depth: 0
-      
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          # Add target for universal builds when enabled
-          targets: ${{ matrix.config.target }}
-          components: rustfmt, clippy
-      
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-          # Cache key includes target for cross-compilation support
-          key: ${{ matrix.config.os }}-${{ matrix.config.target }}
-      
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-      
-      - name: Setup Node.js (fallback for Bun compatibility)
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-      
-      - name: Install Linux system dependencies
-        if: matrix.config.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libssl-dev \
-            libxdo-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev
-      
-      - name: Install macOS system dependencies
-        if: matrix.config.os == 'macos-latest'
-        run: |
-          # Ensure Xcode Command Line Tools are available
-          xcode-select --install 2>/dev/null || true
-          # Install additional dependencies if needed
-          # brew install pkg-config (uncomment if required)
-      
-      # Windows dependencies would go here when Windows builds are enabled:
-      # - name: Install Windows system dependencies
-      #   if: matrix.config.os == 'windows-latest'
-      #   run: |
-      #     # Ensure Microsoft C++ Build Tools are available
-      #     # choco install visualcpp-build-tools (if using chocolatey)
-      
-      - name: Install frontend dependencies
-        run: bun install
-      
-      - name: Run frontend type checking
-        run: bunx tsc --noEmit
-      
-      - name: Run Rust formatting check
-        working-directory: src-tauri
-        run: cargo fmt --all -- --check
-      
-      - name: Run Rust linting
-        working-directory: src-tauri
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      
-      - name: Run Rust tests
-        working-directory: src-tauri
-        run: cargo test --verbose
-      
-      - name: Build application
-        run: |
-          if [ "${{ matrix.config.target }}" != "" ]; then
-            bun run tauri build --target ${{ matrix.config.target }}
-          else
-            bun run tauri build
-          fi
-        shell: bash
-        env:
-          # Code signing environment variables (optional)
-          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          # Ensure consistent builds across platforms
-          TAURI_BUNDLE_IDENTIFIER: so.asterisk.claudia
-      
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: claudia-${{ matrix.config.name }}
-          path: |
-            ${{ matrix.config.artifact_path }}
-            src-tauri/target/release/claudia*
-            src-tauri/target/${{ matrix.config.target }}/release/claudia*
-          retention-days: 30
-          if-no-files-found: warn
-      
-      - name: Upload build logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-logs-${{ matrix.config.name }}
-          path: |
-            src-tauri/target/release/build/*/out.log
-            src-tauri/target/release/build/*/err.log
-          retention-days: 7
-          if-no-files-found: ignore
+    - uses: actions/checkout@v4
+    
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+    
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: latest
+    
+    - name: Install Linux dependencies
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev \
+          patchelf \
+          libxdo-dev \
+          libsoup-3.0-dev \
+          libjavascriptcoregtk-4.1-dev
+    
+    - name: Install frontend dependencies
+      run: bun install
+    
+    - name: Build application
+      run: bun run tauri build
+      # Note: Universal macOS build disabled due to missing x86_64 Claude Code binary
+      # Use: bun run tauri build --target universal-apple-darwin (after Intel binary added)
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: claudia-${{ matrix.platform }}
+        path: |
+          src-tauri/target/release/bundle/
+          src-tauri/target/release/claudia*
+        retention-days: 30
 
-  # Security and quality checks
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      
-      - name: Run security audit
-        working-directory: src-tauri
-        run: cargo audit
-
-  # Release job - creates GitHub releases with all artifacts
   release:
-    name: Create Release
-    needs: [build, security-audit]
+    needs: build
     runs-on: ubuntu-latest
-    # Only run on main branch pushes (not PRs)
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
-    permissions:
-      contents: write  # Required for creating releases
+    if: github.ref == 'refs/heads/main'
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Download all build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: claudia-*
-          merge-multiple: false
-      
-      - name: Display artifact structure
-        run: find artifacts -type f -name "*" | head -20
-      
-      - name: Generate release notes
-        id: release_notes
-        run: |
-          echo "## 🚀 Claudia v${{ github.run_number }}" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "### 📦 Available Downloads" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "- **Linux**: AppImage, .deb package" >> release_notes.md
-          echo "- **macOS**: .dmg installer (Apple Silicon)" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "### 🔧 Build Information" >> release_notes.md
-          echo "- **Commit**: ${{ github.sha }}" >> release_notes.md
-          echo "- **Build Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> release_notes.md
-          echo "- **Workflow Run**: [${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "### ⚠️ Platform Support Status" >> release_notes.md
-          echo "- ✅ **Linux**: Fully supported" >> release_notes.md
-          echo "- ✅ **macOS**: Apple Silicon only (Intel support pending)" >> release_notes.md
-          echo "- ❌ **Windows**: Not yet supported (see issues #78, #83)" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "### 📋 Recent Changes" >> release_notes.md
-          git log --oneline -n 5 --no-decorate >> release_notes.md
-      
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "artifacts/**/*"
-          tag: "v${{ github.run_number }}"
-          name: "Claudia v${{ github.run_number }}"
-          bodyFile: "release_notes.md"
-          draft: false
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: true
-          allowUpdates: false
+    - uses: actions/checkout@v4
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+    
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "artifacts/**/*"
+        tag: "v${{ github.run_number }}"
+        name: "Claudia v${{ github.run_number }}"
+        body: |
+          Auto-generated release from commit ${{ github.sha }}
           
-      - name: Update latest release info
-        run: |
-          echo "## Release Published Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Release**: [v${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ github.run_number }})" >> $GITHUB_STEP_SUMMARY
-          echo "**Download**: Available in [Releases](${{ github.server_url }}/${{ github.repository }}/releases)" >> $GITHUB_STEP_SUMMARY
+          **Available platforms:**
+          - Linux (Ubuntu) - AppImage, .deb
+          - macOS (Apple Silicon) - .dmg
+          
+          **Not yet supported:**
+          - Windows (see #83)
+          - macOS Universal (missing Intel binary)
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,20 @@
 # .github/workflows/build.yml
 name: Build Claudia
-
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
+  workflow_dispatch:    # This allows manual triggering
+  release:              # This triggers on release creation
+    types: [created]
 
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest] # Remove windows-latest temporarily
+        # platform: [ubuntu-latest, windows-latest, macos-latest] # Restore after Windows fixes
     
     runs-on: ${{ matrix.platform }}
     
@@ -47,10 +48,32 @@ jobs:
     - name: Install frontend dependencies
       run: bun install
     
-    - name: Build application
-      run: bun run tauri build
+    - name: Build application (Universal macOS)
+      if: matrix.platform == 'macos-latest'
+      run: bun run tauri build --target universal-apple-darwin
+      env:
+        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
     
-    - name: Upload artifacts
+    - name: Build application (Other platforms)
+      if: matrix.platform != 'macos-latest'
+      run: bun run tauri build
+      env:
+        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+    
+    - name: Upload artifacts (macOS Universal)
+      if: matrix.platform == 'macos-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: claudia-${{ matrix.platform }}
+        path: |
+          src-tauri/target/universal-apple-darwin/release/bundle/
+          src-tauri/target/universal-apple-darwin/release/claudia*
+        retention-days: 30
+    
+    - name: Upload artifacts (Other platforms)
+      if: matrix.platform != 'macos-latest'
       uses: actions/upload-artifact@v4
       with:
         name: claudia-${{ matrix.platform }}


### PR DESCRIPTION
# Add CI/CD Workflow for Multi-Platform Builds

## Overview
Adds a GitHub Actions workflow to automatically build Claudia for Linux and macOS, with automated releases on the main branch.

## What this does
- **Builds** on Linux (Ubuntu) and macOS (Apple Silicon) 
- **Creates releases** with downloadable installers when code is pushed to main
- **Handles dependencies** automatically for each platform

## Current limitations
- **Windows builds disabled** - Due to [[Issue #83](https://github.com/getAsterisk/claudia/issues/83)](https://github.com/getAsterisk/claudia/issues/83) (invalid icon format + Unix imports)
- **macOS Universal builds disabled** - Missing `claude-code-x86_64-apple-darwin` binary

## Files added
- `.github/workflows/build.yml` - Main build and release workflow

## How to enable disabled platforms

### Windows
1. Fix issues in [[#83](https://github.com/getAsterisk/claudia/issues/83)](https://github.com/getAsterisk/claudia/issues/83)
2. Uncomment `windows-latest` in the matrix

### macOS Universal  
1. Add Intel Claude Code binary to `binaries/` directory
2. Change build command to: `bun run tauri build --target universal-apple-darwin`

## Testing
- **Pull requests**: Builds but doesn't create releases
- **Main branch**: Builds and creates releases automatically 
- **Downloads**: Available in GitHub Releases section

---

This provides immediate CI/CD value while being ready for future platform expansion.